### PR TITLE
Fix missing Python dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,6 +10,7 @@ numpy>=1.26.0
 
 # WebSocket communication with Swift
 websockets>=12.0
+orjson>=3.9.0  # Used in main_server.py for faster serialization
 
 # Model utilities
 sentencepiece>=0.2.0


### PR DESCRIPTION
## Summary
- list `orjson` in `python/requirements.txt` as it is imported in `main_server.py`

## Testing
- `python3 -m compileall python`

------
https://chatgpt.com/codex/tasks/task_e_68442a5b15f483268368d98ccfe6e409