### PR TITLE
Remove stray await calls

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -106,10 +106,10 @@ final class ASRBridge: ObservableObject {
 
                 switch message {
                 case let .string(text):
-                    await processTranscriptionEvent(text)
+                    processTranscriptionEvent(text)
                 case let .data(data):
                     if let text = String(data: data, encoding: .utf8) {
-                        await processTranscriptionEvent(text)
+                        processTranscriptionEvent(text)
                     }
                 @unknown default:
                     break
@@ -189,10 +189,10 @@ final class ASRBridge: ObservableObject {
 
                 switch message {
                 case let .string(text):
-                    await processConceptEvent(text)
+                    processConceptEvent(text)
                 case let .data(data):
                     if let text = String(data: data, encoding: .utf8) {
-                        await processConceptEvent(text)
+                        processConceptEvent(text)
                     }
                 @unknown default:
                     break


### PR DESCRIPTION
## Summary
- remove awaits from synchronous helper calls in `ASRBridge`

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684431f478ac83269ce0b6c02b38fd38