### PR TITLE
Fix async usage and shared memory

### DIFF
--- a/Sources/Core/Detectors/FillerDetector.swift
+++ b/Sources/Core/Detectors/FillerDetector.swift
@@ -19,6 +19,8 @@ public final class FillerDetector {
 
     /// Simple threshold helper (≥ 3 fillers in the last 30 words = drift).
     public func isDrifting() -> Bool {
-        return window.count >= 15 && record(word: "") >= 3
+        let words = window.toArray()
+        let fillerCount = words.filter { fillers.contains($0) }.count
+        return words.count >= 15 && fillerCount >= 3
     }
 }

--- a/Sources/Core/IPC/ConceptWebSocketClient.swift
+++ b/Sources/Core/IPC/ConceptWebSocketClient.swift
@@ -38,16 +38,18 @@ public final class ConceptWebSocketClient {
     }
 
     private func receive() {
-        task?.receive(completionHandlerQueue: decodeQueue) { [weak self] result in
+        task?.receive { [weak self] result in
             guard let self = self else { return }
-            switch result {
-            case .failure:
-                self.scheduleReconnect()
-            case let .success(.string(text)):
-                self.decodeAndPublish(text)
-                self.receive()
-            default:
-                self.receive()
+            self.decodeQueue.async {
+                switch result {
+                case .failure:
+                    self.scheduleReconnect()
+                case let .success(.string(text)):
+                    self.decodeAndPublish(text)
+                    self.receive()
+                default:
+                    self.receive()
+                }
             }
         }
     }

--- a/Sources/Core/IPC/SharedRingBuffer.swift
+++ b/Sources/Core/IPC/SharedRingBuffer.swift
@@ -20,11 +20,17 @@ public final class SharedRingBuffer {
 
     public init?() {
         // 1. shm_open (create if needed)
-        fd = shm_open(shmName, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)
+        fd = shmName.withCString { namePtr in
+            shm_open(namePtr, O_RDWR | O_CREAT, mode_t(S_IRUSR | S_IWUSR))
+        }
         if fd == -1 {
             // Attempt to unlink stale segment and retry once
-            shm_unlink(shmName)
-            fd = shm_open(shmName, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)
+            shmName.withCString { namePtr in
+                shm_unlink(namePtr)
+            }
+            fd = shmName.withCString { namePtr in
+                shm_open(namePtr, O_RDWR | O_CREAT, mode_t(S_IRUSR | S_IWUSR))
+            }
             guard fd != -1 else {
                 print("SharedRingBuffer: Failed to create shared memory")
                 return nil
@@ -109,6 +115,8 @@ public final class SharedRingBuffer {
         if lockFd != -1 {
             close(lockFd)
         }
-        shm_unlink(shmName)
+        shmName.withCString { namePtr in
+            shm_unlink(namePtr)
+        }
     }
 }

--- a/Sources/Core/MicPipeline.swift
+++ b/Sources/Core/MicPipeline.swift
@@ -41,7 +41,9 @@ public final class MicPipeline: ObservableObject {
     }
 
     deinit {
-        cleanup()
+        Task { @MainActor in
+            cleanup()
+        }
     }
 
     private func cleanup() {

--- a/Sources/Core/RingBuffer.swift
+++ b/Sources/Core/RingBuffer.swift
@@ -97,6 +97,11 @@ public final class RingBuffer<Element> {
     public var isFull: Bool {
         return lock.withLock { count == capacity }
     }
+
+    /// Current number of elements in the buffer
+    public var countValue: Int {
+        return lock.withLock { count }
+    }
 }
 
 // Extension for NSLock convenience


### PR DESCRIPTION
## Summary
- fix `FillerDetector.isDrifting` logic
- expose `countValue` on `RingBuffer`
- address variadic `shm_open` call
- wrap deinit cleanup in `Task`
- wrap callbacks that touch main actor state in `Task`
- fix `ConceptWebSocketClient.receive` API usage
- use `withCString` for shared memory functions

## Testing
- `swift build -c release` *(fails: no such module 'Combine')*
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684434d7db3483268126035dbb1c930a