### PR TITLE
Update macOS target and fix engine initializer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "fHUD",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v15)],
     products: [
         .executable(name: "fHUD", targets: ["fHUD"]),
     ],

--- a/Sources/UI/AmbientDisplayView.swift
+++ b/Sources/UI/AmbientDisplayView.swift
@@ -84,7 +84,9 @@ struct AmbientDisplayView: View {
     }
 
     private func stopAnimations() {
-        animationEngine.stopEngine()
+        Task { @MainActor in
+            await animationEngine.stopEngine()
+        }
         animationTimer?.invalidate()
         animationTimer = nil
     }


### PR DESCRIPTION
## Summary
- target macOS 15 in Package.swift
- add a convenience initializer for `AnimatedParticle`
- mark AnimationEngine as only available on macOS 15
- make cleanup and stopEngine async and call from the main actor
- update view code to call the async stop method

## Testing
- `swift build` *(fails: 'v15' is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68444abbd18c832692598f67481082f3