### PR TITLE
Fix concurrency and shm_open issues

### DIFF
--- a/Sources/Core/IPC/ConceptWebSocketClient.swift
+++ b/Sources/Core/IPC/ConceptWebSocketClient.swift
@@ -58,7 +58,8 @@ public final class ConceptWebSocketClient {
         do {
             let wrapper = try decoder.decode(MessageContract<ConceptMessage>.self, from: Data(text.utf8))
             guard wrapper.type == "concept" else { return }
-            DispatchQueue.main.async {
+            // Hop onto the main actor for UI-safe publishing
+            Task { @MainActor in
                 self.publisher.send(wrapper.payload)
             }
         } catch {


### PR DESCRIPTION
## Summary
- fix ConceptWebSocketClient main-actor handoff
- add c_shm_open/c_shm_unlink shims on Darwin
- use the shims in SharedRingBuffer

## Testing
- `swift build` *(fails: no such module 'Combine')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445b523a78832688cf65775e3303a1