### PR TITLE
Synchronous deinit cleanup

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -68,9 +68,11 @@ final class ASRBridge: ObservableObject {
     }
 
     deinit {
-        Task { @MainActor in
-            cleanup()
-        }
+        reconnectTimer?.invalidate()
+        reconnectTimer = nil
+        webSocket?.cancel(with: .goingAway, reason: nil)
+        conceptSocket?.cancel(with: .goingAway, reason: nil)
+        cancellables.removeAll()
     }
 
     private func cleanup() {

--- a/Sources/Core/MicPipeline.swift
+++ b/Sources/Core/MicPipeline.swift
@@ -41,9 +41,9 @@ public final class MicPipeline: ObservableObject {
     }
 
     deinit {
-        Task { @MainActor in
-            cleanup()
-        }
+        paceTimer?.invalidate()
+        paceTimer = nil
+        cancellables.removeAll()
     }
 
     private func cleanup() {


### PR DESCRIPTION
## Summary
- remove Task wrappers from `ASRBridge` and `MicPipeline` deinits
- call cleanup synchronously in deinits

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68445c4c8dd883268e86ae7d351c4dc8