### PR TITLE
Add concurrency shims

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -1,3 +1,14 @@
+// ConcurrencyShims.swift
+//
+// Minimal shims so we can access Timer / AnyCancellable from
+// non‑isolated contexts (e.g. default deinits) without warnings.
+
+import Foundation
+import Combine
+
+extension Timer: @unchecked Sendable {}
+extension AnyCancellable: @unchecked Sendable {}
+
 // MARK: - ASRBridge.swift
 //
 // Bridges the Python back end with the SwiftUI interface.  This class


### PR DESCRIPTION
## Summary
- add concurrency shims to ASRBridge so Timer and AnyCancellable can be used from non‑isolated contexts

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6844672818808326bebbc75de488799f