### PR TITLE
Fix WebSocket concept publishing

### DIFF
--- a/Sources/Core/IPC/ConceptWebSocketClient.swift
+++ b/Sources/Core/IPC/ConceptWebSocketClient.swift
@@ -67,11 +67,12 @@ public final class ConceptWebSocketClient {
             guard wrapper.type == "concept" else { return }
 
             // Grab the payload on the decode queue
-            let payload = wrapper.payload
+            let payload  = wrapper.payload          // value type
+            let subject  = publisher                // capture the subject, not self
 
             // Publish on the MainActor to avoid data races
             Task { @MainActor in
-                self.publisher.send(payload)
+                subject.send(payload)
             }
 
         } catch {


### PR DESCRIPTION
## Summary
- avoid capturing `self` when publishing concept messages

## Testing
- `swift test -l` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684468dd04d083269aea5532bf71eca9