### PR TITLE
Fix MetalDetectors hashing

### DIFF
--- a/Sources/Core/Detectors/MetalDetectors.swift
+++ b/Sources/Core/Detectors/MetalDetectors.swift
@@ -175,7 +175,7 @@ class MetalFillerDetector {
         metalDetector = MetalDriftDetector()
 
         // Pre-compute filler word hashes for fast comparison
-        fillerHashes = Set(fillers.map { $0.hash.magnitude })
+        fillerHashes = Set(fillers.map { UInt32(bitPattern: $0.hashValue) })
     }
 
     func record(word: String) -> Int {
@@ -191,7 +191,7 @@ class MetalFillerDetector {
 
     private func metalAcceleratedCount(word: String) -> Int {
         // GPU-accelerated filler detection
-        let wordHash = word.lowercased().hash.magnitude
+        let wordHash = UInt32(bitPattern: word.lowercased().hashValue)
         wordHashes.append(wordHash)
 
         // Keep only recent words


### PR DESCRIPTION
## Summary
- correctly cast String hashes to `UInt32` in `MetalDetectors.swift`

## Testing
- `swift test -v` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68446f064478832696a2c3829a1e2523