### PR TITLE
Fix Metal detectors inheritance

### DIFF
--- a/Sources/Core/Detectors/FillerDetector.swift
+++ b/Sources/Core/Detectors/FillerDetector.swift
@@ -7,9 +7,12 @@
 
 import Foundation
 
-public final class FillerDetector {
-    private let fillers: Set<String> = ["um", "uh", "erm", "hmm", "like"] // tweak anytime
-    private let window = RingBuffer<String>(capacity: 30) // last 30 words
+public class FillerDetector {
+    // Allow subclass access to common properties
+    let fillers: Set<String> = ["um", "uh", "erm", "hmm", "like"] // tweak anytime
+    let window = RingBuffer<String>(capacity: 30) // last 30 words
+
+    public init() {}
 
     /// Feed *one* lowercase word at a time.
     public func record(word: String) -> Int {

--- a/Sources/Core/Detectors/PaceAnalyzer.swift
+++ b/Sources/Core/Detectors/PaceAnalyzer.swift
@@ -14,12 +14,15 @@ public struct PaceMetrics {
     public let isBelowThreshold: Bool
 }
 
-public final class PaceAnalyzer {
-    private var baselineWPM: Float = 150 // default
-    private var runningSum: Float = 0
-    private var buffer: [Float] = []
-    private let capacity = 12
-    private let secondsPerBucket: Float = 5
+public class PaceAnalyzer {
+    // Allow subclasses to reuse core properties
+    var baselineWPM: Float = 150 // default
+    var runningSum: Float = 0
+    var buffer: [Float] = []
+    let capacity = 12
+    let secondsPerBucket: Float = 5
+
+    public init() {}
 
     /// Feed number of *words* spoken during the last 5 seconds.
     public func record(words: Int) -> PaceMetrics {

--- a/Sources/Core/Detectors/PauseDetector.swift
+++ b/Sources/Core/Detectors/PauseDetector.swift
@@ -6,11 +6,12 @@
 
 import Foundation
 
-public final class PauseDetector {
-    private let threshold: TimeInterval
-    private var lastWordTime: TimeInterval?
+public class PauseDetector {
+    // Expose properties for subclasses
+    let threshold: TimeInterval
+    var lastWordTime: TimeInterval?
     // Pre-calculate threshold comparison
-    private var thresholdComparison: TimeInterval
+    var thresholdComparison: TimeInterval
 
     public init(threshold: TimeInterval = 0.3) {
         self.threshold = threshold


### PR DESCRIPTION
## Summary
- allow base detectors to be subclassed
- implement Metal detectors as subclasses
- remove force casts from `DetectorFactory`

## Testing
- `swift build` *(fails: no such module 'Combine')*
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68449b8da600832698906da1530406c4