### PR TITLE
Make filler hashes static

### DIFF
--- a/Sources/Core/Detectors/FillerDetector.swift
+++ b/Sources/Core/Detectors/FillerDetector.swift
@@ -8,8 +8,11 @@
 import Foundation
 
 public class FillerDetector {
+    /// Canonical set of filler words used across detector implementations.
+    public static let fillers: Set<String> = ["um", "uh", "erm", "hmm", "like"]
+
     // Allow subclass access to common properties
-    let fillers: Set<String> = ["um", "uh", "erm", "hmm", "like"] // tweak anytime
+    let fillers: Set<String> = Self.fillers
     let window = RingBuffer<String>(capacity: 30) // last 30 words
 
     public init() {}

--- a/Sources/Core/Detectors/MetalDetectors.swift
+++ b/Sources/Core/Detectors/MetalDetectors.swift
@@ -162,18 +162,25 @@ class MetalDriftDetector {
 // MARK: - Hardware-Accelerated Detector Implementations
 
 @available(macOS 10.13, *)
-class MetalFillerDetector: FillerDetector {
+final class MetalFillerDetector: FillerDetector {
     private let metalDetector: MetalDriftDetector?
 
-    // Vectorized processing using Accelerate
-    private var wordHashes: [UInt32] = []
-    private var fillerHashes: Set<UInt32>
+    // SIMD‑friendly caches
+    private var wordHashes : [UInt32] = []
+
+    /// Pre‑hashed filler words (computed once).
+    private static let prehashed: Set<UInt32> = {
+        return Set(FillerDetector.fillers.map {
+            UInt32(truncatingIfNeeded: $0.hashValue)
+        })
+    }()
+
+    // handy alias
+    private var fillerHashes: Set<UInt32> { Self.prehashed }
 
     override init() {
         metalDetector = MetalDriftDetector()
-
-        // Pre-compute filler word hashes for fast comparison
-        fillerHashes = Set(fillers.map { UInt32(bitPattern: $0.hashValue) })
+        super.init()   // nothing else to do
     }
 
     override func record(word: String) -> Int {


### PR DESCRIPTION
## Summary
- provide canonical filler words as a static property
- pre-compute Metal filler hashes once using a static set

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6844a758525883269a6965085ebe5b7d