### PR TITLE
Apply concurrency fixes

### DIFF
--- a/Sources/UI/HUDOverlayView.swift
+++ b/Sources/UI/HUDOverlayView.swift
@@ -28,7 +28,9 @@ public struct HUDOverlayView: View {
         // Existing transcript setup can stay here …
 
         // Only connect — *do not* create Combine sinks that mutate `self`.
-        conceptClient.connect()
+        Task {
+            await conceptClient.connect()
+        }
     }
 
     // --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- mark Sendable extensions as retroactive
- wrap Timer check in `Task { @MainActor }` to ensure main-actor isolation
- use `let` for `SharedRingBuffer` wrapper
- convert `ConceptWebSocketClient` into an actor
- use async connect in HUD overlay

## Testing
- `swift test -c release` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6846d1f9bfe8832682370f0fd4384e81