### PR TITLE
Fix retransmission message and withCString usage

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -359,8 +359,8 @@ final class ASRBridge: ObservableObject {
 
     private func requestRetransmission(from sequence: UInt32) {
         guard let webSocket else { return }
-        let msg = ["type": "retransmit", "from": sequence]
-        if let data = try? JSONSerialization.data(withJSONObject: msg, options: []) {
+        let msg = RetransmitMessage(from: sequence)
+        if let data = try? JSONEncoder().encode(msg) {
             Task { try? await webSocket.send(.data(data)) }
         }
     }
@@ -505,6 +505,11 @@ struct TranscriptionEvent: Codable {
     let w: String // word
     let t: TimeInterval // timestamp
     let c: Float? // optional confidence score
+}
+
+struct RetransmitMessage: Codable {
+    let type: String = "retransmit"
+    let from: UInt32
 }
 
 struct ConceptEvent: Codable {

--- a/Sources/Core/IPC/SharedRingBuffer.swift
+++ b/Sources/Core/IPC/SharedRingBuffer.swift
@@ -67,7 +67,7 @@ public final class SharedRingBuffer {
         }
         if fd == -1 {
             // Attempt to unlink stale segment and retry once
-            self.shmName.withCString { namePtr in
+            _ = self.shmName.withCString { namePtr in
                 c_shm_unlink(namePtr)
             }
             fd = self.shmName.withCString { namePtr in
@@ -239,7 +239,7 @@ public final class SharedRingBuffer {
         if lockFd != -1 {
             close(lockFd)
         }
-        shmName.withCString { namePtr in
+        _ = shmName.withCString { namePtr in
             c_shm_unlink(namePtr)
         }
     }


### PR DESCRIPTION
## Summary
- use a typed `RetransmitMessage` in `ASRBridge`
- clean up `withCString` side effects in `SharedRingBuffer`

## Testing
- `swift build -c debug` *(fails: no such module 'Combine')*
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68471d86f6248326be78b34b244b3130