### PR TITLE
Implement dispatch source monitoring for shared memory

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -59,7 +59,6 @@ final class ASRBridge: ObservableObject {
 
     private var ringBuffer: SharedRingBuffer?
     private var ringCancellable: AnyCancellable?
-    private var sharedMemoryPoller: Timer?
     private var lastReadPosition: UInt32 = 0
     private var lastSequence: UInt32 = 0
     private var sentinelTimestamp: Date?
@@ -107,7 +106,7 @@ final class ASRBridge: ObservableObject {
         guard ringBuffer == nil else { return }
         if let reader = SharedRingBuffer(name: path) {
             ringBuffer = reader
-            sharedMemoryPoller = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            reader.startMonitoring { [weak self] in
                 Task { @MainActor in
                     self?.checkSharedMemory()
                 }


### PR DESCRIPTION
## Summary
- hook up `DispatchSourceFileSystemObject` in SharedRingBuffer
- expose the ring buffer's file descriptor
- use new monitoring API in `ASRBridge` to read words on write events

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684721ae871083268cae63a5bcf6618e