### PR TITLE
Clarify shared ring buffer event handler

### DIFF
--- a/Sources/Core/IPC/SharedRingBuffer.swift
+++ b/Sources/Core/IPC/SharedRingBuffer.swift
@@ -170,7 +170,7 @@ public final class SharedRingBuffer {
             eventMask: .write,
             queue: queue
         )
-        s.setEventHandler(handler)
+        s.setEventHandler(handler) // use closure directly
         s.setCancelHandler { [weak self] in
             self?.source = nil
         }


### PR DESCRIPTION
## Summary
- document direct closure usage for `startMonitoring` in `SharedRingBuffer`

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_684725c0dc5c832691efc043868c56b3