### PR TITLE
Implement batch 4 fallback logic

### DIFF
--- a/Sources/UI/AmbientDisplayView.swift
+++ b/Sources/UI/AmbientDisplayView.swift
@@ -32,6 +32,10 @@ struct AmbientDisplayView: View {
     private let charcoal = Color(red: 0.12, green: 0.12, blue: 0.12)
     private let dimAmber = Color(red: 0.96, green: 0.65, blue: 0.14, opacity: 0.3)
 
+    private var conceptColor: Color {
+        asrBridge.currentSource == .sharedMemory ? amber : .red
+    }
+
     // Layout constants for 1280x800 display
     private let margin: CGFloat = 30
     private let transcriptHeight: CGFloat = 60
@@ -60,7 +64,7 @@ struct AmbientDisplayView: View {
                                 width: CGFloat(particle.size),
                                 height: CGFloat(particle.size)
                             )),
-                            with: .color(amber.opacity(0.3))
+                            with: .color(conceptColor.opacity(0.3))
                         )
                     }
                 }
@@ -108,7 +112,7 @@ struct AmbientDisplayView: View {
                     .padding(.vertical, 4)
                     .background(
                         RoundedRectangle(cornerRadius: 12)
-                            .fill(amber.opacity(particleOpacity(for: concept)))
+                            .fill(conceptColor.opacity(particleOpacity(for: concept)))
                     )
                     .position(position)
                     .animation(.easeInOut(duration: 0.3), value: position)
@@ -130,7 +134,7 @@ struct AmbientDisplayView: View {
 
                     context.stroke(
                         path,
-                        with: .color(amber.opacity(Double(connection.strength) * 0.5)),
+                        with: .color(conceptColor.opacity(Double(connection.strength) * 0.5)),
                         lineWidth: 1.5
                     )
                 }

--- a/Sources/UI/HUDOverlayView.swift
+++ b/Sources/UI/HUDOverlayView.swift
@@ -14,6 +14,7 @@ public struct HUDOverlayView: View {
     // --------------------------------------------------------------------
     // Dependencies
     @EnvironmentObject private var mic: MicPipeline
+    @EnvironmentObject private var asrBridge: ASRBridge
 
     // --------------------------------------------------------------------
     // Concept‑popup state
@@ -62,6 +63,10 @@ public struct HUDOverlayView: View {
                 }
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(.yellow)
+
+                Text("Source: \(asrBridge.currentSource.rawValue)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(asrBridge.currentSource == .sharedMemory ? .green : .orange)
             }
             .padding(12)
             .background(Color.black.opacity(0.65))


### PR DESCRIPTION
## Summary
- add CRC error counter to shared memory reader
- add automatic fallback between shared memory and WebSocket
- highlight active data source in debug HUD
- change concept particle color when falling back

## Testing
- `python -m py_compile python/main_server.py`
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68496ff85ed48326be3b303f24eea265