### PR TITLE
Fix SharedRingBuffer callbacks

### DIFF
--- a/Sources/Core/IPC/SharedRingBuffer.swift
+++ b/Sources/Core/IPC/SharedRingBuffer.swift
@@ -170,7 +170,9 @@ public final class SharedRingBuffer {
             eventMask: .write,
             queue: queue
         )
-        s.setEventHandler(handler) // use closure directly
+        s.setEventHandler {
+            handler()
+        }
         s.setCancelHandler { [weak self] in
             self?.source = nil
         }


### PR DESCRIPTION
## Summary
- ensure dispatch source handler is a closure
- build with corrected setEventHandler usage

## Testing
- `swift build --product fHUD` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6849789d8c1c83269acd3a80f653b76b