### PR TITLE
Fix MainActor isolation for health monitor timer

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -186,7 +186,9 @@ final class ASRBridge: ObservableObject {
 
     private func startHealthMonitor() {
         healthTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.evaluateDataSource()
+            Task { @MainActor in
+                self?.evaluateDataSource()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure ASRBridge health timer callback runs on `MainActor`

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68498141acbc8326bc64a91017b47de1