### PR TITLE
Fix Codable warning in RetransmitMessage

### DIFF
--- a/Sources/Core/ASRBridge.swift
+++ b/Sources/Core/ASRBridge.swift
@@ -561,8 +561,14 @@ struct TranscriptionEvent: Codable {
 }
 
 struct RetransmitMessage: Codable {
-    let type: String = "retransmit"
+    /// Fixed message type for retransmission requests
+    /// Excluded from Codable to silence warnings
+    let type = "retransmit"
     let from: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case from
+    }
 }
 
 struct ConceptEvent: Codable {


### PR DESCRIPTION
## Summary
- remove explicit type annotation from `RetransmitMessage`
- exclude `type` from Codable keys to silence compiler warning

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6849833d4be48326b7e522ea51b462fb